### PR TITLE
将mq中打印DefaultMQProducer得地方替换fastjson的toJSONString

### DIFF
--- a/spring-boot-starter-rocketmq/src/main/java/io/github/opensabe/spring/boot/starter/rocketmq/RocketMQTemplateBeanPostProcessor.java
+++ b/spring-boot-starter-rocketmq/src/main/java/io/github/opensabe/spring/boot/starter/rocketmq/RocketMQTemplateBeanPostProcessor.java
@@ -1,7 +1,7 @@
 package io.github.opensabe.spring.boot.starter.rocketmq;
 
+import com.alibaba.fastjson.JSON;
 import io.github.opensabe.common.executor.ThreadPoolFactory;
-import io.github.opensabe.common.utils.json.JsonUtil;
 import jakarta.annotation.Nonnull;
 import lombok.extern.log4j.Log4j2;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
@@ -26,7 +26,8 @@ public class RocketMQTemplateBeanPostProcessor implements BeanPostProcessor {
             producer.setAsyncSenderExecutor(asyncSenderExecutor);
             // 设置超时时间为5秒
             producer.setMqClientApiTimeout(5 * 1000);
-            log.info("RocketMQTemplateBeanPostProcessor-postProcessAfterInitialization: {} producer: {}", beanName, JsonUtil.toJSONString(producer));
+            // FIXME 对于producer的toJSONString时候需要注意，DefaultMQProducer与DefaultMQProducerImpl中循环引用了DefaultMQProducer，使用jackson进行操作时候，会报 【Infinite recursion (StackOverflowError)】
+            log.info("RocketMQTemplateBeanPostProcessor-postProcessAfterInitialization: {} producer: {}", beanName, JSON.toJSONString(producer));
 
         }
         return bean;


### PR DESCRIPTION
## 修改内容

将mq中打印DefaultMQProducer得地方替换fastjson的toJSONString

## 目标分支

将要合并到的目标分支为main。

## 测试计划

在io.github.opensabe.common.utils.JsonUtilTest类中已经测试了两个类的toJSONString结果完全一致。

## 提醒

@opensabe-tech

## 相关链接

无