### PR TITLE
使用兼容fastjson1的2.x版本

### DIFF
--- a/common-utils/src/test/java/io/github/opensabe/common/utils/JsonUtilTest.java
+++ b/common-utils/src/test/java/io/github/opensabe/common/utils/JsonUtilTest.java
@@ -1,5 +1,6 @@
 package io.github.opensabe.common.utils;
 
+import com.alibaba.fastjson.JSON;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.github.opensabe.common.utils.json.JsonUtil;
@@ -206,5 +207,17 @@ public class JsonUtilTest {
         return """
                 {"brithDay": "%s"}
                 """.formatted(now.format(DateTimeFormatter.ofPattern(format)));
+    }
+
+    /**
+     * 测试fastjson序列化：
+     * 针对fastjson 1.2.83  以及兼容的2.0.51 版本结果
+     */
+    @Test
+    void testFastjsonSerialize () {
+        // fastjson(1.2.83)  序列化结果：{}  不支持record
+        // fastjson(2.0.51)  序列化结果：{"age":10,"brithDay":1722396158549,"name":"lily"}   支持record
+        // JsonUtil  序列化结果：{"name":"lily","age":10,"brithDay":1722396388723}           支持record
+        System.out.println(JSON.toJSONString(new User("lily", 10, LocalDateTime.now())));
     }
 }

--- a/spring-cloud-parent/spring-framework-parent-common/pom.xml
+++ b/spring-cloud-parent/spring-framework-parent-common/pom.xml
@@ -19,8 +19,8 @@
     <properties>
         <commons-collections4.version>4.4</commons-collections4.version>
         <commons-text.version>1.10.0</commons-text.version>
-        <!--   fastjson不能升级到2.0，必须在1.x的基础上升级     -->
-        <fastjson.version>1.2.83</fastjson.version>
+        <!-- 使用兼容fastjson1的2.x版本：https://mvnrepository.com/artifact/com.alibaba/fastjson/2.0.51 -->
+        <fastjson.version>2.0.51</fastjson.version>
         <fastutil.version>8.5.12</fastutil.version>
         <transmittable-thread-local.version>2.14.2</transmittable-thread-local.version>
         <joda-time.version>2.12.5</joda-time.version>


### PR DESCRIPTION
## 修改内容

使用兼容fastjson1的2.x版本

## 目标分支

将要合并到的目标分支为main。

## 测试计划

在io.github.opensabe.common.utils.JsonUtilTest类中已经测试了两个版本的结果完全一致。

## 提醒

@opensabe-tech

## 相关链接

无

