### PR TITLE
使用兼容fastjson1的2.x版本

### DIFF
--- a/spring-cloud-parent/spring-framework-parent-common/pom.xml
+++ b/spring-cloud-parent/spring-framework-parent-common/pom.xml
@@ -19,8 +19,8 @@
     <properties>
         <commons-collections4.version>4.4</commons-collections4.version>
         <commons-text.version>1.10.0</commons-text.version>
-        <!--   fastjson不能升级到2.0，必须在1.x的基础上升级     -->
-        <fastjson.version>1.2.83</fastjson.version>
+        <!-- 使用兼容fastjson1的2.x版本：https://mvnrepository.com/artifact/com.alibaba/fastjson/2.0.51 -->
+        <fastjson.version>2.0.51</fastjson.version>
         <fastutil.version>8.5.12</fastutil.version>
         <transmittable-thread-local.version>2.14.2</transmittable-thread-local.version>
         <joda-time.version>2.12.5</joda-time.version>


### PR DESCRIPTION
修改内容
使用兼容fastjson1的2.x版本

目标分支
将要合并到的目标分支为1.0.3.3。

测试计划
在io.github.opensabe.common.utils.JsonUtilTest类中已经测试了两个版本的结果完全一致。

提醒
@opensabe-tech

相关链接
无