### PR TITLE
优化 secret 日志检查性能消耗，针对异步日志

### DIFF
--- a/spring-cloud-parent/spring-framework-parent-common/src/main/java/io/github/opensabe/common/secret/GlobalSecretManager.java
+++ b/spring-cloud-parent/spring-framework-parent-common/src/main/java/io/github/opensabe/common/secret/GlobalSecretManager.java
@@ -29,9 +29,9 @@ public class GlobalSecretManager {
         for (Map.Entry<String, Map<String, Set<String>>> stringMapEntry : cache.asMap().entrySet()) {
             for (Map.Entry<String, Set<String>> stringSetEntry : stringMapEntry.getValue().entrySet()) {
                 for (String sensitiveString : stringSetEntry.getValue()) {
-                    if (StringUtils.containsIgnoreCase(filteredContent, sensitiveString)) {
+                    if (StringUtils.contains(filteredContent, sensitiveString)) {
                         foundSensitiveString = true;
-                        filteredContent = StringUtils.replaceIgnoreCase(filteredContent, sensitiveString, "******");
+                        filteredContent = StringUtils.replace(filteredContent, sensitiveString, "******");
                         foundKeys.add("SecretProvider: " + stringMapEntry.getKey() + ", key: " + stringSetEntry.getKey());
                     }
                 }

--- a/spring-cloud-parent/spring-framework-parent-common/src/main/java/io/github/opensabe/common/secret/Log4j2SecretCheckFilter.java
+++ b/spring-cloud-parent/spring-framework-parent-common/src/main/java/io/github/opensabe/common/secret/Log4j2SecretCheckFilter.java
@@ -1,6 +1,8 @@
 package io.github.opensabe.common.secret;
 
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.github.opensabe.common.utils.SpringUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
@@ -13,17 +15,31 @@ import org.apache.logging.log4j.core.filter.AbstractFilter;
 import org.apache.logging.log4j.message.Message;
 import org.springframework.context.ApplicationContext;
 
+import java.time.Duration;
 import java.util.Objects;
 
 @Plugin(name = "SecretCheckFilter", category = "Core", elementType = "filter", printObject = true)
 public class Log4j2SecretCheckFilter extends AbstractFilter {
+    private final Cache<String, Boolean> hasSecretCache = Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(1)).build();
     @PluginFactory
     public static Log4j2SecretCheckFilter createFilter() {
         return new Log4j2SecretCheckFilter();
     }
     @Override
     public Result filter(LogEvent event) {
-        return check(event.getMessage().getFormattedMessage());
+        //对于异步日志，这里是单线程执行的，所以不能有太大消耗，不能每次都检查
+        String format = event.getMessage().getFormat();
+        Boolean ifPresent = hasSecretCache.getIfPresent(format);
+        if (Objects.nonNull(ifPresent)) {
+            if (ifPresent) {
+                return check(event.getMessage().getFormattedMessage());
+            } else {
+                return Result.NEUTRAL;
+            }
+        }
+        Result check = check(event.getMessage().getFormattedMessage());
+        hasSecretCache.put(format, check == Result.DENY);
+        return check;
     }
 
     private Result check(String message) {


### PR DESCRIPTION
## 修改内容

Log4j2 检查 Secret 的判断增加缓存，不使用 StringUtils.containsIgnoreCase，因为这个方法对于长字符串 CPU 消耗几何级增长

## 目标分支

main

## 测试计划

无需测试，单元测试已经涵盖

## 提醒

@houjianpo163 

## 相关链接



