### PR TITLE
将redis docker替换成valkey docker

### DIFF
--- a/common-testcontainers/src/main/java/io/github/opensabe/common/testcontainers/CustomizedRedisContainer.java
+++ b/common-testcontainers/src/main/java/io/github/opensabe/common/testcontainers/CustomizedRedisContainer.java
@@ -13,7 +13,7 @@ public class CustomizedRedisContainer extends GenericContainer<CustomizedRedisCo
     public static final int REDIS_PORT = 6379;
 
     public CustomizedRedisContainer() {
-        super("redis");
+        super("valkey/valkey:8.0.1-bookworm");
     }
 
     @Override

--- a/common-testcontainers/src/main/java/io/github/opensabe/common/testcontainers/CustomizedRocketMQContainer.java
+++ b/common-testcontainers/src/main/java/io/github/opensabe/common/testcontainers/CustomizedRocketMQContainer.java
@@ -15,6 +15,7 @@ public class CustomizedRocketMQContainer extends GenericContainer<CustomizedRock
     public static final int BROKER_PORT = 10911;
 
     public CustomizedRocketMQContainer() {
+        // mac m1芯片(ARM64) 可以使用 "dyrnq/rocketmq:5.2.0" 来跑单测
         super("apache/rocketmq:5.2.0");
         withExposedPorts(NAMESRV_PORT, BROKER_PORT, BROKER_PORT - 2);
     }

--- a/spring-boot-starter-redisson/src/test/java/io/github/opensabe/common/redisson/test/MultiRedisTest.java
+++ b/spring-boot-starter-redisson/src/test/java/io/github/opensabe/common/redisson/test/MultiRedisTest.java
@@ -51,12 +51,12 @@ public class MultiRedisTest {
     }
 
     @ClassRule
-    static GenericContainer redis1 = new FixedHostPortGenericContainer("redis")
+    public static GenericContainer redis1 = new FixedHostPortGenericContainer("valkey/valkey:8.0.1-bookworm")
             .withFixedExposedPort(6378,6379)
             .withExposedPorts(6379)
             .withCommand("redis-server");
     @ClassRule
-    static GenericContainer redis2 = new FixedHostPortGenericContainer("redis")
+    public static GenericContainer redis2 = new FixedHostPortGenericContainer("valkey/valkey:8.0.1-bookworm")
             .withFixedExposedPort(6380,6379)
             .withExposedPorts(6379)
             .withCommand("redis-server");


### PR DESCRIPTION
## 修改内容

将redis docker替换成valkey docker

## 目标分支

main

## 测试计划

原有redis的单元测试。

## 提醒

无。


