### PR TITLE
Lettuce自定义observation会导致Registry提前初始化，导致obeservation失效

### DIFF
--- a/spring-boot-starter-redisson/pom.xml
+++ b/spring-boot-starter-redisson/pom.xml
@@ -58,6 +58,11 @@
             <artifactId>spring-boot-starter-webflux</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.github.opensabe-tech</groupId>

--- a/spring-boot-starter-redisson/src/main/java/io/github/opensabe/common/redisson/autoconfig/LettuceAutoConfiguration.java
+++ b/spring-boot-starter-redisson/src/main/java/io/github/opensabe/common/redisson/autoconfig/LettuceAutoConfiguration.java
@@ -16,6 +16,7 @@
 package io.github.opensabe.common.redisson.autoconfig;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.context.annotation.Import;
 
 import io.github.opensabe.common.redisson.config.LettuceConfiguration;
@@ -23,7 +24,7 @@ import io.github.opensabe.common.redisson.config.LettuceConfiguration;
 /**
  * Lettuce
  */
-@AutoConfiguration
+@AutoConfiguration(before = {RedisAutoConfiguration.class, MultiRedisAutoConfiguration.class})
 @Import(LettuceConfiguration.class)
 public class LettuceAutoConfiguration {
 }

--- a/spring-boot-starter-redisson/src/main/java/io/github/opensabe/common/redisson/config/LettuceConfiguration.java
+++ b/spring-boot-starter-redisson/src/main/java/io/github/opensabe/common/redisson/config/LettuceConfiguration.java
@@ -15,31 +15,68 @@
  */
 package io.github.opensabe.common.redisson.config;
 
-import java.time.Duration;
-
-import org.springframework.boot.autoconfigure.data.redis.ClientResourcesBuilderCustomizer;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
-
+import io.github.opensabe.common.observation.UnifiedObservationFactory;
 import io.lettuce.core.event.DefaultEventPublisherOptions;
 import io.lettuce.core.metrics.DefaultCommandLatencyCollector;
 import io.lettuce.core.metrics.DefaultCommandLatencyCollectorOptions;
 import io.lettuce.core.tracing.MicrometerTracing;
+import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
+import org.springframework.boot.autoconfigure.data.redis.ClientResourcesBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.data.util.Lazy;
+
+import java.time.Duration;
 
 @Configuration(proxyBeanMethods = false)
 public class LettuceConfiguration {
     private static final String DEFAULT_APPLICATION_NAME = "application";
 
     @Bean
-    public ClientResourcesBuilderCustomizer clientResourcesBuilderCustomizer(ObservationRegistry observationRegistry, Environment environment) {
+    public ClientResourcesBuilderCustomizer clientResourcesBuilderCustomizer(UnifiedObservationFactory unifiedObservationFactory, Environment environment) {
         String applicationName = environment.getProperty("spring.application.name", DEFAULT_APPLICATION_NAME);
         return builder -> builder
-                .tracing(new MicrometerTracing(observationRegistry, applicationName))
+                .tracing(new MicrometerTracing(new LazyObservationRegistry(unifiedObservationFactory), applicationName))
                 .commandLatencyRecorder(new DefaultCommandLatencyCollector(DefaultCommandLatencyCollectorOptions.builder().enable().resetLatenciesAfterEvent(true).build()))
                 .commandLatencyPublisherOptions(DefaultEventPublisherOptions.builder().eventEmitInterval(Duration.ofSeconds(10)).build())
                 ;
+    }
+
+
+    public static class LazyObservationRegistry implements ObservationRegistry {
+
+        private final Lazy<ObservationRegistry> observationRegistry;
+
+        public LazyObservationRegistry(UnifiedObservationFactory unifiedObservationFactory) {
+            this.observationRegistry = Lazy.of(unifiedObservationFactory::getObservationRegistry);
+        }
+
+        @Override
+        public Observation getCurrentObservation() {
+            return observationRegistry.get().getCurrentObservation();
+        }
+
+        @Override
+        public Observation.Scope getCurrentObservationScope() {
+            return observationRegistry.get().getCurrentObservationScope();
+        }
+
+        @Override
+        public void setCurrentObservationScope(Observation.Scope current) {
+            observationRegistry.get().setCurrentObservationScope(current);
+        }
+
+        @Override
+        public ObservationConfig observationConfig() {
+            return observationRegistry.get().observationConfig();
+        }
+
+        @Override
+        public boolean isNoop() {
+            return observationRegistry.get().isNoop();
+        }
     }
 
 }

--- a/spring-boot-starter-redisson/src/test/java/io/github/opensabe/common/redisson/test/RedisComponentTest.java
+++ b/spring-boot-starter-redisson/src/test/java/io/github/opensabe/common/redisson/test/RedisComponentTest.java
@@ -163,7 +163,6 @@ public class RedisComponentTest extends BaseRedissonTest {
     @Test
     void testObservation () {
         ResponseEntity<String> entity = restTemplate.getForEntity("/test", String.class);
-        System.out.println(entity);
         Assertions.assertEquals("test", entity.getBody());
         Assertions.assertTrue(CustomerHandler.called.get());
 

--- a/spring-boot-starter-redisson/src/test/java/io/github/opensabe/common/redisson/test/RedisComponentTest.java
+++ b/spring-boot-starter-redisson/src/test/java/io/github/opensabe/common/redisson/test/RedisComponentTest.java
@@ -20,6 +20,7 @@ import io.github.opensabe.common.redisson.observation.ObservedRedissonClient;
 import io.github.opensabe.common.redisson.test.common.BaseRedissonTest;
 import io.github.opensabe.common.utils.SpringUtil;
 import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.github.opensabe.common.redisson.observation.ObservedRedissonClient;
 import io.github.opensabe.common.redisson.test.common.BaseRedissonTest;
@@ -74,6 +76,25 @@ public class RedisComponentTest extends BaseRedissonTest {
             return new TestController();
         }
 
+
+        @Bean
+        public CustomerHandler customerHandler () {
+            return new CustomerHandler();
+        }
+
+    }
+
+    public static class  CustomerHandler implements ObservationHandler<Observation.Context> {
+        static final AtomicBoolean called = new AtomicBoolean(false);
+        @Override
+        public boolean supportsContext(Observation.Context context) {
+            return true;
+        }
+
+        @Override
+        public void onStop(Observation.Context context) {
+            called.set(true);
+        }
     }
 
     @Log4j2
@@ -144,5 +165,7 @@ public class RedisComponentTest extends BaseRedissonTest {
         ResponseEntity<String> entity = restTemplate.getForEntity("/test", String.class);
         System.out.println(entity);
         Assertions.assertEquals("test", entity.getBody());
+        Assertions.assertTrue(CustomerHandler.called.get());
+
     }
 }

--- a/spring-boot-starter-redisson/src/test/java/io/github/opensabe/common/redisson/test/common/BaseRedissonTest.java
+++ b/spring-boot-starter-redisson/src/test/java/io/github/opensabe/common/redisson/test/common/BaseRedissonTest.java
@@ -30,7 +30,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
         classes = BaseRedissonTest.App.class,
         properties = {
                 "eureka.client.enabled=false",
-        }
+        },
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
 @JfrEventTest
 public abstract class BaseRedissonTest {

--- a/spring-boot-starter-redisson/src/test/resources/log4j2.xml
+++ b/spring-boot-starter-redisson/src/test/resources/log4j2.xml
@@ -6,9 +6,6 @@
         <Property name="LOG_EXCEPTION_CONVERSION_WORD">%xwEx</Property>
         <Property name="LOG_LEVEL_PATTERN">%5p</Property>
         <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd HH:mm:ss.SSS</Property>
-        <Property name="logFormat">
-            %d{${LOG_DATEFORMAT_PATTERN}} ${LOG_LEVEL_PATTERN} [${springAppName},%X{traceId},%X{spanId}] [${sys:PID}] [%t][%C:%L]: %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}
-        </Property>
         <Property name="CONSOLE_LOG_PATTERN">
             %clr{%d{${LOG_DATEFORMAT_PATTERN}}}{faint} %clr{${LOG_LEVEL_PATTERN}} [${springAppName},%X{traceId},%X{spanId}] %clr{[${sys:PID}]}{magenta} %clr{[%t]}{faint}%clr{[%C:%L]}{cyan}%clr{:}{faint}%m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}
         </Property>
@@ -22,29 +19,10 @@
                              onMismatch="DENY"/>
             <PatternLayout pattern="${CONSOLE_LOG_PATTERN}"/>
         </Console>
-
-        <RollingFile name="file" fileName="${LOG_ROOT}/app.log" append="true"
-                     filePattern="${LOG_ROOT}/app.log.%d{yyyy-MM-dd.HH}.gz">
-            <PatternLayout pattern="${logFormat}"/>
-            <Policies>
-                <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
-            </Policies>
-            <DefaultRolloverStrategy>
-                <Delete basePath="${LOG_ROOT}" maxDepth="1">
-                    <IfFileName glob="*app.log.*">
-                        <IfAny>
-                            <IfAccumulatedFileCount exceeds="6"/>
-                        </IfAny>
-                    </IfFileName>
-                </Delete>
-            </DefaultRolloverStrategy>
-        </RollingFile>
     </appenders>
 
     <loggers>
-        <!--default logger -->
         <Asyncroot level="info" includeLocation="true">
-            <!--            <appender-ref ref="file" />-->
             <appender-ref ref="console"/>
         </Asyncroot>
 

--- a/spring-cloud-parent/pom.xml
+++ b/spring-cloud-parent/pom.xml
@@ -29,7 +29,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <java.version>21</java.version>
-        
+
         <opensabe.version>2.0.0-SNAPSHOT</opensabe.version>
 
         <disruptor.version>4.0.0</disruptor.version>


### PR DESCRIPTION
## 修改内容

ClientResources.tracing使用自定义的LazyObservationRegistry

## 目标分支

main

## 测试计划

RedisComponentTest 测试通过，在advisor中注入redis相关bean，并且自定义observationHandler，看生不生效

## 提醒

@opensabe-tech @LeaonUniverse @houjianpo163 

## 相关链接



