### PR TITLE
unique跟日志内容用空格分开

### DIFF
--- a/spring-cloud-parent/spring-framework-parent-common/src/main/java/io/github/opensabe/common/utils/AlarmUtil.java
+++ b/spring-cloud-parent/spring-framework-parent-common/src/main/java/io/github/opensabe/common/utils/AlarmUtil.java
@@ -127,7 +127,7 @@ public class AlarmUtil {
     }
 
     public static void fatal(String message, Set<String> groups, Boolean unique, Object... params) {
-        final String messageResult = groups.toString() + " " + (unique ? "UNIQUE" : "") + message;
+        final String messageResult = groups.toString() + " " + (unique ? "UNIQUE" : " ") + message;
         log.fatal(messageResult, params);
         Pair<String, String> traceSpan = analysisTraceSpan();
         MessageFactory messageFactory = AlarmLog.log.getMessageFactory();


### PR DESCRIPTION
## 修改内容

修复AlarmUtil使用参数构建的app.log日志，unique跟日志中间没有空格的问题


